### PR TITLE
Add middleware to set REMOTE_ADDR from X-Forwarded-For when using a UNIX socket for the proxy

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -279,6 +279,12 @@ mailman3_wsgi_command: >-
 # mailman3_domains is set, this should contain a '%i' for the systemd service instance.
 mailman3_wsgi_socket: "/run/mailman3-web{{ mailman3_domains is defined | ternary('@%i', '') }}.sock"
 
+# Custom middleware derived from the removed django.middleware.http.SetRemoteAddrFromForwardedFor is needed to set
+# REMOTE_ADDR from X-Forwarded-For when using a UNIX domain socket rather than TCP for mailman3_wsgi_socket, since
+# Postorius/HyperKitty use REMOTE_ADDR rather than the other headers. See
+# https://docs.djangoproject.com/en/4.1/releases/1.1/#removed-setremoteaddrfromforwardedfor-middleware
+mailman3_django_middleware_module_name: "ansible_galaxyproject_mailman3_middleware"
+
 # Django superusers. Set at least one or you will be unable to manage your Mailman server from the web UI. The password
 # here is the initial password, once created it can be changed from within Django and will not be changed back by the
 # role.

--- a/files/middleware.py
+++ b/files/middleware.py
@@ -1,0 +1,30 @@
+__all__ = [
+    'SetRemoteAddrFromForwardedFor',
+]
+
+class SetRemoteAddrFromForwardedFor(object):
+    """
+    Middleware that sets REMOTE_ADDR based on HTTP_X_FORWARDED_FOR, if the
+    latter is set. This is useful if you're sitting behind a reverse proxy that
+    causes each request's REMOTE_ADDR to be set to 127.0.0.1.
+
+    Note that this does NOT validate HTTP_X_FORWARDED_FOR. If you're not behind
+    a reverse proxy that sets HTTP_X_FORWARDED_FOR automatically, do not use
+    this middleware. Anybody can spoof the value of HTTP_X_FORWARDED_FOR, and
+    because this sets REMOTE_ADDR based on HTTP_X_FORWARDED_FOR, that means
+    anybody can "fake" their IP address. Only use this when you can absolutely
+    trust the value of HTTP_X_FORWARDED_FOR.
+    """
+    def __init__(self, get_response):
+        self.get_response = get_response
+
+    def __call__(self, request):
+        try:
+            real_ip = request.META['HTTP_X_FORWARDED_FOR']
+            # HTTP_X_FORWARDED_FOR can be a comma-separated list of IPs. The
+            # client's IP will be the first one.
+            real_ip = real_ip.split(",")[0].strip()
+            request.META['REMOTE_ADDR'] = real_ip
+        except KeyError:
+            pass
+        return self.get_response(request)

--- a/tasks/config.yml
+++ b/tasks/config.yml
@@ -32,3 +32,13 @@
   when: mailman3_django_urls_module_name
   notify:
     - Reload mailman3-web service
+
+- name: Install custom middleware
+  ansible.builtin.copy:
+    src: "middleware.py"
+    mode: "0644"
+    dest: "{{ mailman3_django_project_dir }}/{{ mailman3_django_middleware_module_name }}.py"
+    backup: "{{ mailman3_backup_configs }}"
+  when: mailman3_wsgi_socket.startswith("/")
+  notify:
+    - Reload mailman3-web service

--- a/templates/settings.py.j2
+++ b/templates/settings.py.j2
@@ -202,3 +202,8 @@ COMPRESS_OFFLINE = {{ __mailman3_django_config_merged.compress_offline | bool | 
 
 HYPERKITTY_ATTACHMENT_FOLDER = '{{ __mailman3_django_config_merged.hyperkitty_attachment_folder }}'
 {% endif %}
+{% if mailman3_wsgi_socket.startswith("/") %}
+
+# Add custom middleware to set REMOTE_ADDR when using a unix domain socket
+MIDDLEWARE = MIDDLEWARE + ('{{ mailman3_django_middleware_module_name }}.SetRemoteAddrFromForwardedFor',)
+{% endif %}


### PR DESCRIPTION
Because a remote address does not exist in this context, `REMOTE_ADDR` will be unset, and HyperKitty relies on `REMOTE_ADDR` instead of any of the other common proxy headers for its auth handling. Without this, mailman core will log messages like this when attempting to archive:

```
archiving failed, re-queuing (mailing-list list-id.example.org, message <MESSAGE-ID@example.com>)
Exception in the HyperKitty archiver: <html><title>Forbidden</title><body>
                <h1>Access is forbidden</h1><p>Please check the IP addresses
                 assigned to MAILMAN_ARCHIVER_FROM in the settings file.
                </p></body></html>
```

And HyperKitty will log:

```
ERROR hyperkitty.views.mailman Access to the archiving API endpoint was forbidden from IP , your MAILMAN_ARCHIVER_FROM setting may be misconfigured
```