### PR TITLE
Modify default paths

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -304,8 +304,8 @@ mailman3_default_from_user: postorius
 # Override upstream (Mailman) Django paths - set 'mailman3_postorius_root' to an empty string to serve Mailman from the
 # root of your web server. Setting either option overrides the value of ROOT_URLCONF in the Django settings to use a
 # copy of url.py templated from the role instead of the one installed with Mailman.
-# mailman3_postorius_root: 'postorius/'
-# mailman3_hyperkitty_root: 'hyperkitty/'
+# mailman3_postorius_root: 'mailman3/'
+# mailman3_hyperkitty_root: 'archives/'
 mailman3_django_urls_module_name: >-
   {{
     (mailman3_postorius_root is defined or mailman3_hyperkitty_root is defined) | ternary(

--- a/tasks/config.yml
+++ b/tasks/config.yml
@@ -14,7 +14,7 @@
   ansible.builtin.copy:
     content: |
       [general]
-      base_url: http://localhost/{{ mailman3_hyperkitty_root | default('hyperkitty/') }}
+      base_url: http://localhost/{{ mailman3_hyperkitty_root | default('archives/') }}
       api_key: {{ mailman3_archiver_key }}
     dest: "{{ mailman3_core_etc_dir }}/hyperkitty.cfg"
     group: "{{ __mailman3_core_group_name }}"

--- a/templates/urls.py.j2
+++ b/templates/urls.py.j2
@@ -23,14 +23,14 @@ from django.urls import path, reverse_lazy
 from django.views.generic import RedirectView
 
 urlpatterns = [
-{% if mailman3_postorius_root | default('postorius/') %}
+{% if mailman3_postorius_root | default('mailman3/') %}
     path(
         '',
         RedirectView.as_view(url=reverse_lazy('list_index'), permanent=True),
     ),
 {% endif %}
-    path(r'{{ mailman3_postorius_root | default("postorius/") }}', include('postorius.urls')),
-    path(r'{{ mailman3_hyperkitty_root | default("hyperkitty/") }}', include('hyperkitty.urls')),
+    path(r'{{ mailman3_postorius_root | default("mailman3/") }}', include('postorius.urls')),
+    path(r'{{ mailman3_hyperkitty_root | default("archives/") }}', include('hyperkitty.urls')),
     path('', include('django_mailman3.urls')),
     path('accounts/', include('allauth.urls')),
     path('admin/', admin.site.urls),


### PR DESCRIPTION
The upstream mailman suite is using paths `archives/` and` mailman3/` instead of `hyperkitty/` and `postorius/`

This can be observed in the URL https://lists.mailman3.org/archives/ or in a file that gets installed by mailman:  /opt/mailman3/lib/python3.10/site-packages/mailman_web/urls.py

Hyperkitty archives won't work correctly if the path is mismatched.   So, align the paths with installed packages by using `archives/` and` mailman3/` .

Actually, another enhancement is useful also, which would be to use a variable to specify the server name in hyperkitty.cfg instead of hardcoding "localhost", because after installing SSL certificates "localhost" won't be guaranteed to work.    That's a different update though.  Not included here.
