### PR TITLE
Remove removed argv parameter warn.

### DIFF
--- a/handlers/main.yml
+++ b/handlers/main.yml
@@ -8,9 +8,6 @@
 
 - name: Restart mailman3-core service
   ansible.builtin.command: systemctl try-restart {{ mailman3_core_service_name }}.service
-  args:
-    # can't noqa a multi-line yaml string and noqa command-instead-of-module makes the line fail the line length rule
-    warn: false
   when:
     - mailman3_process_manager == "systemd"
     - ansible_virtualization_type != "docker"


### PR DESCRIPTION
Remove parameter that has been deprecated in Ansible 2.11 and was removed in 2.14.

See: https://stackoverflow.com/questions/74544930/ansible-unsupported-parameters-for-ansible-legacy-command-module-warn